### PR TITLE
Fix validation by only validating after substitution - this was alrea…

### DIFF
--- a/.github/workflows/spec-check-filter-release.yaml
+++ b/.github/workflows/spec-check-filter-release.yaml
@@ -551,7 +551,7 @@ jobs:
         env:
           SPEC_TYPE: ${{ inputs.spec-type }}
           SPEC_VALIDATION_TYPE: ${{ inputs.spec-validation-type }}
-          SPEC_SUB_PATH: ${{ steps.spec-package-prepare.outputs.SPEC_SUB_PATH }}
+          SPEC_SUB_PATH: ${{ steps.docker-build.outputs.docker-substituted-sub-path }}
           SPEC_JSON: ${{ steps.spec-package-prepare.outputs.SPEC_JSON }}
         run: ./.github/buildon-github-actions/src/scripts/main/spec-validate
       - name: Pass check - Spec Validate

--- a/src/workflow-templates/spec-check-filter-release.yaml
+++ b/src/workflow-templates/spec-check-filter-release.yaml
@@ -325,7 +325,7 @@ jobs:
         env:
           SPEC_TYPE: ${{ inputs.spec-type }}
           SPEC_VALIDATION_TYPE: ${{ inputs.spec-validation-type }}
-          SPEC_SUB_PATH: ${{ steps.spec-package-prepare.outputs.SPEC_SUB_PATH }}
+          SPEC_SUB_PATH: ${{ steps.docker-build.outputs.docker-substituted-sub-path }}
           SPEC_JSON: ${{ steps.spec-package-prepare.outputs.SPEC_JSON }}
         run: ./.github/buildon-github-actions/src/scripts/main/spec-validate
       # INJECT: github-check-end(name="Spec Validate", id="check-spec-validate")


### PR DESCRIPTION
…dy the intent - however I guess it slipped through as it failed the first time with the scripts api which requires a X.Y format version field.