### PR TITLE
Add docker multipush everywhere it'll be useful and…

### DIFF
--- a/.github/workflows/docker-build-dockerfile.yaml
+++ b/.github/workflows/docker-build-dockerfile.yaml
@@ -68,6 +68,11 @@ on:
         required: false
         type: string
         default: ''
+      docker-push-targets:
+        description: 'JSON array of additional push targets [{registry, base-path?}]'
+        required: false
+        type: string
+        default: ''
       # Version generator inputs (pass-through)
       release-branch:
         description: 'The release branch name'
@@ -557,6 +562,36 @@ jobs:
           action: fail
           check-run-id: ${{ steps.check-docker-build.outputs.check-run-id }}
 
+      # === Docker Multi-Tag ===
+      - name: Start check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        id: check-docker-multi-tag
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Push → Docker Multi-Tag'
+      - name: Tag images for additional registries
+        id: docker-multi-tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-tag
+        with:
+          docker-image-full-uri: ${{ steps.docker-build.outputs.docker-target-image-full-uri }}
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+      - name: Pass check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-docker-multi-tag.outputs.check-run-id }}
+      - name: Fail check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && failure() && steps.check-docker-multi-tag.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-docker-multi-tag.outputs.check-run-id }}
+
       # === Post-docker Tests ===
       - name: Start check - Post-docker Tests
         if: inputs.post-docker-tests-script-sub-path != '' && success()
@@ -688,6 +723,36 @@ jobs:
         with:
           action: fail
           check-run-id: ${{ steps.check-docker-push.outputs.check-run-id }}
+
+      # === Docker Multi-Push ===
+      - name: Start check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        id: check-docker-multi-push
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Push → Docker Multi-Push'
+      - name: Push images to additional registries
+        id: docker-multi-push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-push
+        with:
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+          is-release: ${{ steps.versions.outputs.is-release }}
+      - name: Pass check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-docker-multi-push.outputs.check-run-id }}
+      - name: Fail check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && failure() && steps.check-docker-multi-push.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-docker-multi-push.outputs.check-run-id }}
 
       # === GitHub Release ===
       - name: Start check - GitHub Release

--- a/.github/workflows/docker-build-retag.yaml
+++ b/.github/workflows/docker-build-retag.yaml
@@ -34,6 +34,11 @@ on:
         required: false
         type: string
         default: ''
+      docker-push-targets:
+        description: 'JSON array of additional push targets [{registry, base-path?}]'
+        required: false
+        type: string
+        default: ''
       # Version generator inputs (pass-through)
       release-branch:
         description: 'The release branch name'
@@ -514,6 +519,36 @@ jobs:
           action: fail
           check-run-id: ${{ steps.check-docker-retag.outputs.check-run-id }}
 
+      # === Docker Multi-Tag ===
+      - name: Start check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        id: check-docker-multi-tag
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Push → Docker Multi-Tag'
+      - name: Tag images for additional registries
+        id: docker-multi-tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-tag
+        with:
+          docker-image-full-uri: ${{ steps.docker-build.outputs.docker-target-image-full-uri }}
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+      - name: Pass check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-docker-multi-tag.outputs.check-run-id }}
+      - name: Fail check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && failure() && steps.check-docker-multi-tag.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-docker-multi-tag.outputs.check-run-id }}
+
       # === GitHub Release Prepare ===
       - name: Start check - GitHub Release Prepare
         if: inputs.github-release-enabled == true && success()
@@ -612,6 +647,36 @@ jobs:
         with:
           action: fail
           check-run-id: ${{ steps.check-docker-push.outputs.check-run-id }}
+
+      # === Docker Multi-Push ===
+      - name: Start check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        id: check-docker-multi-push
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Push → Docker Multi-Push'
+      - name: Push images to additional registries
+        id: docker-multi-push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-push
+        with:
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+          is-release: ${{ steps.versions.outputs.is-release }}
+      - name: Pass check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-docker-multi-push.outputs.check-run-id }}
+      - name: Fail check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && failure() && steps.check-docker-multi-push.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-docker-multi-push.outputs.check-run-id }}
 
       # === GitHub Release ===
       - name: Start check - GitHub Release

--- a/.github/workflows/kubernetes-app-docker-dockerfile.yaml
+++ b/.github/workflows/kubernetes-app-docker-dockerfile.yaml
@@ -84,6 +84,11 @@ on:
         required: false
         type: string
         default: ''
+      docker-push-targets:
+        description: 'JSON array of additional push targets [{registry, base-path?}]'
+        required: false
+        type: string
+        default: ''
       # Version generator inputs (pass-through)
       release-branch:
         description: 'The release branch name'
@@ -603,6 +608,36 @@ jobs:
           action: fail
           check-run-id: ${{ steps.check-docker-build.outputs.check-run-id }}
 
+      # === Docker Multi-Tag ===
+      - name: Start check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        id: check-docker-multi-tag
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Publish → Docker Multi-Tag'
+      - name: Tag images for additional registries
+        id: docker-multi-tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-tag
+        with:
+          docker-image-full-uri: ${{ steps.docker-build.outputs.docker-target-image-full-uri }}
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+      - name: Pass check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-docker-multi-tag.outputs.check-run-id }}
+      - name: Fail check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && failure() && steps.check-docker-multi-tag.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-docker-multi-tag.outputs.check-run-id }}
+
       # === Post-docker Tests ===
       - name: Start check - Post-docker Tests
         if: inputs.post-docker-tests-script-sub-path != '' && success()
@@ -744,6 +779,36 @@ jobs:
         with:
           action: fail
           check-run-id: ${{ steps.check-manifest-repo-provider-package.outputs.check-run-id }}
+
+      # === Manifest Multi-Tag ===
+      - name: Start check - Manifest Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        id: check-manifest-multi-tag
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Publish → Manifest Multi-Tag'
+      - name: Tag manifest images for additional registries
+        id: manifest-multi-tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-tag
+        with:
+          docker-image-full-uri: ${{ steps.manifest-repo-provider-package.outputs.manifests-uri }}
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}-manifests
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+      - name: Pass check - Manifest Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-manifest-multi-tag.outputs.check-run-id }}
+      - name: Fail check - Manifest Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && failure() && steps.check-manifest-multi-tag.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-manifest-multi-tag.outputs.check-run-id }}
 
       # === Post-package Tests ===
       - name: Start check - Post-package Tests
@@ -888,6 +953,36 @@ jobs:
           action: fail
           check-run-id: ${{ steps.check-docker-push.outputs.check-run-id }}
 
+      # === Docker Multi-Push ===
+      - name: Start check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        id: check-docker-multi-push
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Publish → Docker Multi-Push'
+      - name: Push images to additional registries
+        id: docker-multi-push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-push
+        with:
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+          is-release: ${{ steps.versions.outputs.is-release }}
+      - name: Pass check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-docker-multi-push.outputs.check-run-id }}
+      - name: Fail check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && failure() && steps.check-docker-multi-push.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-docker-multi-push.outputs.check-run-id }}
+
       # === Manifest Repo Provider Publish ===
       - name: Start check - Publish Manifests via Repo Provider
         if: steps.versions.outputs.is-release == 'true' && success()
@@ -923,6 +1018,36 @@ jobs:
         with:
           action: fail
           check-run-id: ${{ steps.check-manifest-repo-provider-publish.outputs.check-run-id }}
+
+      # === Manifest Multi-Push ===
+      - name: Start check - Manifest Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        id: check-manifest-multi-push
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Publish → Manifest Multi-Push'
+      - name: Push manifest images to additional registries
+        id: manifest-multi-push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-push
+        with:
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}-manifests
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+          is-release: ${{ steps.versions.outputs.is-release }}
+      - name: Pass check - Manifest Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-manifest-multi-push.outputs.check-run-id }}
+      - name: Fail check - Manifest Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && failure() && steps.check-manifest-multi-push.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-manifest-multi-push.outputs.check-run-id }}
 
       # === GitHub Release ===
       - name: Start check - GitHub Release

--- a/.github/workflows/kubernetes-app-docker-retag.yaml
+++ b/.github/workflows/kubernetes-app-docker-retag.yaml
@@ -86,6 +86,11 @@ on:
         required: false
         type: string
         default: ''
+      docker-push-targets:
+        description: 'JSON array of additional push targets [{registry, base-path?}]'
+        required: false
+        type: string
+        default: ''
       # Version generator inputs (pass-through)
       release-branch:
         description: 'The release branch name'
@@ -560,6 +565,36 @@ jobs:
           action: fail
           check-run-id: ${{ steps.check-docker-retag.outputs.check-run-id }}
 
+      # === Docker Multi-Tag ===
+      - name: Start check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        id: check-docker-multi-tag
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Publish → Docker Multi-Tag'
+      - name: Tag images for additional registries
+        id: docker-multi-tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-tag
+        with:
+          docker-image-full-uri: ${{ steps.docker-build.outputs.docker-target-image-full-uri }}
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+      - name: Pass check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-docker-multi-tag.outputs.check-run-id }}
+      - name: Fail check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && failure() && steps.check-docker-multi-tag.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-docker-multi-tag.outputs.check-run-id }}
+
       # === Pre-package Prepare ===
       - name: Start check - Pre-package Prepare
         if: inputs.pre-package-prepare-script-sub-path != '' && success()
@@ -668,6 +703,36 @@ jobs:
         with:
           action: fail
           check-run-id: ${{ steps.check-manifest-repo-provider-package.outputs.check-run-id }}
+
+      # === Manifest Multi-Tag ===
+      - name: Start check - Manifest Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        id: check-manifest-multi-tag
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Publish → Manifest Multi-Tag'
+      - name: Tag manifest images for additional registries
+        id: manifest-multi-tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-tag
+        with:
+          docker-image-full-uri: ${{ steps.manifest-repo-provider-package.outputs.manifests-uri }}
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}-manifests
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+      - name: Pass check - Manifest Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-manifest-multi-tag.outputs.check-run-id }}
+      - name: Fail check - Manifest Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && failure() && steps.check-manifest-multi-tag.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-manifest-multi-tag.outputs.check-run-id }}
 
       # === Post-package Tests ===
       - name: Start check - Post-package Tests
@@ -812,6 +877,36 @@ jobs:
           action: fail
           check-run-id: ${{ steps.check-docker-push.outputs.check-run-id }}
 
+      # === Docker Multi-Push ===
+      - name: Start check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        id: check-docker-multi-push
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Publish → Docker Multi-Push'
+      - name: Push images to additional registries
+        id: docker-multi-push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-push
+        with:
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+          is-release: ${{ steps.versions.outputs.is-release }}
+      - name: Pass check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-docker-multi-push.outputs.check-run-id }}
+      - name: Fail check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && failure() && steps.check-docker-multi-push.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-docker-multi-push.outputs.check-run-id }}
+
       # === Manifest Repo Provider Publish ===
       - name: Start check - Publish Manifests via Repo Provider
         if: steps.versions.outputs.is-release == 'true' && success()
@@ -847,6 +942,36 @@ jobs:
         with:
           action: fail
           check-run-id: ${{ steps.check-manifest-repo-provider-publish.outputs.check-run-id }}
+
+      # === Manifest Multi-Push ===
+      - name: Start check - Manifest Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        id: check-manifest-multi-push
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Publish → Manifest Multi-Push'
+      - name: Push manifest images to additional registries
+        id: manifest-multi-push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-push
+        with:
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}-manifests
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+          is-release: ${{ steps.versions.outputs.is-release }}
+      - name: Pass check - Manifest Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-manifest-multi-push.outputs.check-run-id }}
+      - name: Fail check - Manifest Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && failure() && steps.check-manifest-multi-push.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-manifest-multi-push.outputs.check-run-id }}
 
       # === GitHub Release ===
       - name: Start check - GitHub Release

--- a/.github/workflows/kubernetes-app-manifests-only.yaml
+++ b/.github/workflows/kubernetes-app-manifests-only.yaml
@@ -68,6 +68,11 @@ on:
         required: false
         type: string
         default: ''
+      docker-push-targets:
+        description: 'JSON array of additional push targets [{registry, base-path?}]'
+        required: false
+        type: string
+        default: ''
       # Version generator inputs (pass-through)
       release-branch:
         description: 'The release branch name'
@@ -609,6 +614,36 @@ jobs:
           action: fail
           check-run-id: ${{ steps.check-manifest-repo-provider-package.outputs.check-run-id }}
 
+      # === Manifest Multi-Tag ===
+      - name: Start check - Manifest Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        id: check-manifest-multi-tag
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Publish → Manifest Multi-Tag'
+      - name: Tag manifest images for additional registries
+        id: manifest-multi-tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-tag
+        with:
+          docker-image-full-uri: ${{ steps.manifest-repo-provider-package.outputs.manifests-uri }}
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}-manifests
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+      - name: Pass check - Manifest Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-manifest-multi-tag.outputs.check-run-id }}
+      - name: Fail check - Manifest Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && failure() && steps.check-manifest-multi-tag.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-manifest-multi-tag.outputs.check-run-id }}
+
       # === Post-package Tests ===
       - name: Start check - Post-package Tests
         if: inputs.post-package-tests-script-sub-path != '' && success()
@@ -759,6 +794,36 @@ jobs:
         with:
           action: fail
           check-run-id: ${{ steps.check-manifest-repo-provider-publish.outputs.check-run-id }}
+
+      # === Manifest Multi-Push ===
+      - name: Start check - Manifest Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        id: check-manifest-multi-push
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Publish → Manifest Multi-Push'
+      - name: Push manifest images to additional registries
+        id: manifest-multi-push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-push
+        with:
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}-manifests
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+          is-release: ${{ steps.versions.outputs.is-release }}
+      - name: Pass check - Manifest Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-manifest-multi-push.outputs.check-run-id }}
+      - name: Fail check - Manifest Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker' && failure() && steps.check-manifest-multi-push.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-manifest-multi-push.outputs.check-run-id }}
 
       # === GitHub Release ===
       - name: Start check - GitHub Release

--- a/.github/workflows/spec-check-filter-release.yaml
+++ b/.github/workflows/spec-check-filter-release.yaml
@@ -67,6 +67,11 @@ on:
         required: false
         type: string
         default: ''
+      docker-push-targets:
+        description: 'JSON array of additional push targets [{registry, base-path?}]'
+        required: false
+        type: string
+        default: ''
       # Version generator inputs (pass-through)
       release-branch:
         description: 'The release branch name'
@@ -552,6 +557,36 @@ jobs:
           action: fail
           check-run-id: ${{ steps.check-docker-build.outputs.check-run-id }}
 
+      # === Docker Multi-Tag ===
+      - name: Start check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        id: check-docker-multi-tag
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Push → Docker Multi-Tag'
+      - name: Tag images for additional registries
+        id: docker-multi-tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-tag
+        with:
+          docker-image-full-uri: ${{ steps.docker-build.outputs.docker-target-image-full-uri }}
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+      - name: Pass check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-docker-multi-tag.outputs.check-run-id }}
+      - name: Fail check - Docker Multi-Tag
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && failure() && steps.check-docker-multi-tag.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-docker-multi-tag.outputs.check-run-id }}
+
       # === Spec Validate ===
       - name: Start check - Spec Validate
         id: check-spec-validate
@@ -742,6 +777,36 @@ jobs:
         with:
           action: fail
           check-run-id: ${{ steps.check-docker-push.outputs.check-run-id }}
+
+      # === Docker Multi-Push ===
+      - name: Start check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        id: check-docker-multi-push
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: start
+          check-name: 'Build & Push → Docker Multi-Push'
+      - name: Push images to additional registries
+        id: docker-multi-push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/docker-multi-push
+        with:
+          docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+          docker-tag: ${{ steps.versions.outputs.docker-tag }}
+          docker-push-targets: ${{ inputs.docker-push-targets }}
+          is-release: ${{ steps.versions.outputs.is-release }}
+      - name: Pass check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && success()
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: pass
+          check-run-id: ${{ steps.check-docker-multi-push.outputs.check-run-id }}
+      - name: Fail check - Docker Multi-Push
+        if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && failure() && steps.check-docker-multi-push.outputs.check-run-id != ''
+        uses: ./.github/buildon-github-actions/src/actions/github-check-run
+        with:
+          action: fail
+          check-run-id: ${{ steps.check-docker-multi-push.outputs.check-run-id }}
 
       # === GitHub Release ===
       - name: Start check - GitHub Release

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See [`examples/`](examples/) for more usage patterns.
 | [`docker-build-retag-base-path.yaml`](examples/docker-build-retag-base-path.yaml) | Many registries use base paths in addition to the normal image name for projects or teams |
 | [`docker-build-retag-custom-registry.yaml`](examples/docker-build-retag-custom-registry.yaml) | Push to a registry other than GHCR (Nexus, ECR, GCR, Harbor, etc) |
 | [`docker-build-retag.yaml`](examples/docker-build-retag.yaml) | Pull an upstream image, retag with your name and new version, push to your registry |
+| [`docker-push-targets.yaml`](examples/docker-push-targets.yaml) | Push the same Docker image to multiple registries |
 | [`docker-registry-logins-explicit.yaml`](examples/docker-registry-logins-explicit.yaml) | More typing, but shows exactly what the workflow receives |
 | [`docker-registry-logins-ghcr-pat.yaml`](examples/docker-registry-logins-ghcr-pat.yaml) |   - Push to packages in a different repo or org (GITHUB_TOKEN is scoped to current repo) |
 | [`docker-registry-logins-inherit.yaml`](examples/docker-registry-logins-inherit.yaml) | Secret values are looked up by the names specified in the config |
@@ -81,6 +82,8 @@ See [`examples/`](examples/) for more usage patterns.
 | `basic-quality-checks` | Basic quality checks for commits and branches |
 | `docker-build-dockerfile` | Builds a Docker image from a Dockerfile with token substitution (build only, use docker-push to push) |
 | `docker-build-retag` | Pulls and retags Docker images (no push) |
+| `docker-multi-push` | Pushes Docker image to multiple registries |
+| `docker-multi-tag` | Tags a Docker image for multiple registries |
 | `docker-push` | Pushes a Docker image to registry |
 | `docker-registry-logins` | Authenticate to container registries (GHCR by default, configure others as needed) |
 | `git-push-tag` | Pushes an existing git tag to origin |
@@ -110,6 +113,7 @@ See [`examples/`](examples/) for more usage patterns.
 | `block-slashes` | boolean | `false` | DEPRECATED: Use block-slash-containing-branches instead |
 | `config-sub-path` | string | `src/config` | Directory containing user-defined token files (relative) |
 | `config-value-trailing-newline` | string | `strip-for-single-line` | How to handle trailing newlines in config values (strip-for-single-line, preserve-all, always-strip-one-newline) |
+| `docker-push-targets` | string | `""` | JSON array of additional push targets [{registry, base-path?}] |
 | `docker-registry-logins` | string | `""` | YAML config for Docker registry logins (registry URL as key) |
 | `docker-source-base-path` | string | `""` | Path between registry and image name (e.g., library) |
 | `docker-source-image-name` | string | *required* | Upstream image name (e.g., nginx) |

--- a/docs/docker-build-dockerfile.md
+++ b/docs/docker-build-dockerfile.md
@@ -18,6 +18,7 @@ Docker Build Dockerfile
 | `config-value-trailing-newline` | string | `strip-for-single-line` | How to handle trailing newlines in config values (strip-for-single-line, preserve-all, always-strip-one-newline) |
 | `docker-target-registry` | string | `ghcr.io` | Target container registry |
 | `docker-target-base-path` | string | `""` | Path between registry and image name (auto-set for GHCR) |
+| `docker-push-targets` | string | `""` | JSON array of additional push targets [{registry, base-path?}] |
 | `release-branch` | string | `main` | The release branch name |
 | `additional-release-branches` | string | `""` | Comma-separated list of additional release branches |
 | `block-slashes` | boolean | `false` | DEPRECATED: Use block-slash-containing-branches instead |

--- a/docs/docker-build-retag.md
+++ b/docs/docker-build-retag.md
@@ -12,6 +12,7 @@ Docker Build Retag
 | `docker-source-tag` | string | *required* | Upstream image tag (e.g., 1.25) |
 | `docker-target-registry` | string | `ghcr.io` | Target container registry |
 | `docker-target-base-path` | string | `""` | Path between registry and image name (auto-set for GHCR) |
+| `docker-push-targets` | string | `""` | JSON array of additional push targets [{registry, base-path?}] |
 | `release-branch` | string | `main` | The release branch name |
 | `additional-release-branches` | string | `""` | Comma-separated list of additional release branches |
 | `block-slashes` | boolean | `false` | DEPRECATED: Use block-slash-containing-branches instead |

--- a/docs/kubernetes-app-docker-dockerfile.md
+++ b/docs/kubernetes-app-docker-dockerfile.md
@@ -21,6 +21,7 @@ Kubernetes App - Docker Dockerfile
 | `manifests-packaging-base-image` | string | `""` | Base image for manifest packaging (default: scratch) |
 | `docker-target-registry` | string | `ghcr.io` | Target container registry |
 | `docker-target-base-path` | string | `""` | Path between registry and image name (auto-set for GHCR) |
+| `docker-push-targets` | string | `""` | JSON array of additional push targets [{registry, base-path?}] |
 | `release-branch` | string | `main` | The release branch name |
 | `additional-release-branches` | string | `""` | Comma-separated list of additional release branches |
 | `max-version-parts` | number | `3` | Maximum allowed version parts (fail if exceeded) |

--- a/docs/kubernetes-app-docker-retag.md
+++ b/docs/kubernetes-app-docker-retag.md
@@ -22,6 +22,7 @@ Kubernetes App - Docker Retag
 | `manifests-packaging-base-image` | string | `""` | Base image for manifest packaging (default: scratch) |
 | `docker-target-registry` | string | `ghcr.io` | Target container registry |
 | `docker-target-base-path` | string | `""` | Path between registry and image name (auto-set for GHCR) |
+| `docker-push-targets` | string | `""` | JSON array of additional push targets [{registry, base-path?}] |
 | `release-branch` | string | `main` | The release branch name |
 | `additional-release-branches` | string | `""` | Comma-separated list of additional release branches |
 | `max-version-parts` | number | `3` | Maximum allowed version parts (fail if exceeded) |

--- a/docs/kubernetes-app-manifests-only.md
+++ b/docs/kubernetes-app-manifests-only.md
@@ -18,6 +18,7 @@ Kubernetes App - Manifests Only
 | `manifests-packaging-base-image` | string | `""` | Base image for manifest packaging (default: scratch) |
 | `docker-target-registry` | string | `ghcr.io` | Target container registry |
 | `docker-target-base-path` | string | `""` | Path between registry and image name (auto-set for GHCR) |
+| `docker-push-targets` | string | `""` | JSON array of additional push targets [{registry, base-path?}] |
 | `release-branch` | string | `main` | The release branch name |
 | `additional-release-branches` | string | `""` | Comma-separated list of additional release branches |
 | `max-version-parts` | number | `3` | Maximum allowed version parts (fail if exceeded) |

--- a/docs/spec-check-filter-release.md
+++ b/docs/spec-check-filter-release.md
@@ -18,6 +18,7 @@ Spec Check Filter Release
 | `config-value-trailing-newline` | string | `strip-for-single-line` | How to handle trailing newlines in config values (strip-for-single-line, preserve-all, always-strip-one-newline) |
 | `docker-target-registry` | string | `ghcr.io` | Target container registry |
 | `docker-target-base-path` | string | `""` | Path between registry and image name (auto-set for GHCR) |
+| `docker-push-targets` | string | `""` | JSON array of additional push targets [{registry, base-path?}] |
 | `release-branch` | string | `main` | The release branch name |
 | `additional-release-branches` | string | `""` | Comma-separated list of additional release branches |
 | `block-slashes` | boolean | `false` | DEPRECATED: Use block-slash-containing-branches instead |

--- a/examples/additional-release-branches.yaml
+++ b/examples/additional-release-branches.yaml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   build:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/basic-quality-and-versioning.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/basic-quality-and-versioning.yaml@1.0.40
     permissions:
       contents: write
       checks: write

--- a/examples/basic-quality-and-versioning.yaml
+++ b/examples/basic-quality-and-versioning.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/basic-quality-and-versioning.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/basic-quality-and-versioning.yaml@1.0.40
     permissions:
       contents: write
       checks: write

--- a/examples/docker-build-dockerfile-no-squash.yaml
+++ b/examples/docker-build-dockerfile-no-squash.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.40
     permissions:
       contents: write
       packages: write
@@ -118,6 +118,19 @@ jobs:
 # └─────────────────────────────────────────────────────────────────────────┘
 #     with:
 #       output-sub-path: 'build'  # Default is 'target'
+
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │ Multi-Registry Push                                                     │
+# └─────────────────────────────────────────────────────────────────────────┘
+# Push the same image to additional registries (e.g., multiple AWS accounts)
+# See docker-push-targets.yaml example for full details
+#
+#     with:
+#       docker-push-targets: |
+#         [
+#           {"registry": "123456789012.dkr.ecr.us-east-1.amazonaws.com"},
+#           {"registry": "other.registry.com", "base-path": "my-team"}
+#         ]
 
 # ┌─────────────────────────────────────────────────────────────────────────┐
 # │ Registry Credentials                                                    │

--- a/examples/docker-build-dockerfile.yaml
+++ b/examples/docker-build-dockerfile.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   build:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.40
     permissions:
       contents: write
       packages: write
@@ -120,6 +120,19 @@ jobs:
 # └─────────────────────────────────────────────────────────────────────────┘
 #     with:
 #       output-sub-path: 'build'  # Default is 'target'
+
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │ Multi-Registry Push                                                     │
+# └─────────────────────────────────────────────────────────────────────────┘
+# Push the same image to additional registries (e.g., multiple AWS accounts)
+# See docker-push-targets.yaml example for full details
+#
+#     with:
+#       docker-push-targets: |
+#         [
+#           {"registry": "123456789012.dkr.ecr.us-east-1.amazonaws.com"},
+#           {"registry": "other.registry.com", "base-path": "my-team"}
+#         ]
 
 # ┌─────────────────────────────────────────────────────────────────────────┐
 # │ Registry Credentials                                                    │

--- a/examples/docker-build-retag-base-path.yaml
+++ b/examples/docker-build-retag-base-path.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   retag:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-retag.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-retag.yaml@1.0.40
     permissions:
       contents: write
       packages: write
@@ -123,6 +123,19 @@ jobs:
 # └─────────────────────────────────────────────────────────────────────────┘
 #     with:
 #       output-sub-path: 'build'  # Default is 'target'
+
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │ Multi-Registry Push                                                     │
+# └─────────────────────────────────────────────────────────────────────────┘
+# Push the same image to additional registries (e.g., multiple AWS accounts)
+# See docker-push-targets.yaml example for full details
+#
+#     with:
+#       docker-push-targets: |
+#         [
+#           {"registry": "123456789012.dkr.ecr.us-east-1.amazonaws.com"},
+#           {"registry": "other.registry.com", "base-path": "my-team"}
+#         ]
 
 # ┌─────────────────────────────────────────────────────────────────────────┐
 # │ Registry Credentials                                                    │

--- a/examples/docker-build-retag-custom-registry.yaml
+++ b/examples/docker-build-retag-custom-registry.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   retag:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-retag.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-retag.yaml@1.0.40
     permissions:
       contents: write
       packages: write
@@ -129,6 +129,19 @@ jobs:
 # └─────────────────────────────────────────────────────────────────────────┘
 #     with:
 #       output-sub-path: 'build'  # Default is 'target'
+
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │ Multi-Registry Push                                                     │
+# └─────────────────────────────────────────────────────────────────────────┘
+# Push the same image to additional registries (e.g., multiple AWS accounts)
+# See docker-push-targets.yaml example for full details
+#
+#     with:
+#       docker-push-targets: |
+#         [
+#           {"registry": "123456789012.dkr.ecr.us-east-1.amazonaws.com"},
+#           {"registry": "other.registry.com", "base-path": "my-team"}
+#         ]
 
 # ┌─────────────────────────────────────────────────────────────────────────┐
 # │ Registry Credentials                                                    │

--- a/examples/docker-build-retag.yaml
+++ b/examples/docker-build-retag.yaml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   retag:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-retag.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-retag.yaml@1.0.40
     permissions:
       contents: write
       packages: write
@@ -123,6 +123,19 @@ jobs:
 # └─────────────────────────────────────────────────────────────────────────┘
 #     with:
 #       output-sub-path: 'build'  # Default is 'target'
+
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │ Multi-Registry Push                                                     │
+# └─────────────────────────────────────────────────────────────────────────┘
+# Push the same image to additional registries (e.g., multiple AWS accounts)
+# See docker-push-targets.yaml example for full details
+#
+#     with:
+#       docker-push-targets: |
+#         [
+#           {"registry": "123456789012.dkr.ecr.us-east-1.amazonaws.com"},
+#           {"registry": "other.registry.com", "base-path": "my-team"}
+#         ]
 
 # ┌─────────────────────────────────────────────────────────────────────────┐
 # │ Registry Credentials                                                    │

--- a/examples/docker-push-targets.yaml
+++ b/examples/docker-push-targets.yaml
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: CC0-1.0
+# This example is released to the public domain. Use freely without attribution.
+#
+# Docker Push Targets - Multi-Registry Publishing
+#
+# Push the same Docker image to multiple registries. Useful for:
+# - AWS Lambda in multiple accounts (each needs its own ECR)
+# - Multi-cloud deployments (GHCR + ECR + GCR)
+# - Internal mirrors alongside public registries
+#
+# The primary image is always pushed to the target registry (GHCR by default).
+# Additional targets receive the same image with identical tags.
+#
+# Copy this to .github/workflows/build.yaml in your repo.
+
+name: Docker Push Targets
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.40
+    permissions:
+      contents: write
+      packages: write
+      checks: write
+    with:
+      # JSON array of additional push targets
+      # Each target needs: registry (required), base-path (optional)
+      docker-push-targets: |
+        [
+          {"registry": "123456789012.dkr.ecr.us-east-1.amazonaws.com"},
+          {"registry": "987654321098.dkr.ecr.us-west-2.amazonaws.com", "base-path": "my-team"}
+        ]
+      # Configure registry credentials for the additional targets
+      docker-registry-logins: |
+        123456789012.dkr.ecr.us-east-1.amazonaws.com:
+          username: AWS
+          password: ECR_TOKEN_EAST
+        987654321098.dkr.ecr.us-west-2.amazonaws.com:
+          username: AWS
+          password: ECR_TOKEN_WEST
+    secrets:
+      docker-registry-logins-secrets: |
+        {
+          "ECR_TOKEN_EAST": "${{ secrets.ECR_TOKEN_EAST }}",
+          "ECR_TOKEN_WEST": "${{ secrets.ECR_TOKEN_WEST }}"
+        }
+
+# ┌───────────────────────────────────────────────────────────────────────────┐
+# │ How It Works                                                              │
+# └───────────────────────────────────────────────────────────────────────────┘
+#
+# 1. Image is built and tagged for primary registry (GHCR by default)
+# 2. Docker Multi-Tag: Image is tagged for each additional target
+# 3. Primary image is pushed to GHCR
+# 4. Docker Multi-Push: Image is pushed to each additional target
+#
+# For Kubernetes app workflows, manifest packages are also multi-pushed.
+
+# ┌───────────────────────────────────────────────────────────────────────────┐
+# │ Target Format                                                             │
+# └───────────────────────────────────────────────────────────────────────────┘
+#
+# Each target in the JSON array:
+#   registry   - Required. The registry URL (e.g., "ecr.aws/123456789012")
+#   base-path  - Optional. Path between registry and image name
+#
+# Examples:
+#   {"registry": "docker.io", "base-path": "myorg"}
+#     -> docker.io/myorg/image-name:tag
+#
+#   {"registry": "123456789012.dkr.ecr.us-east-1.amazonaws.com"}
+#     -> 123456789012.dkr.ecr.us-east-1.amazonaws.com/image-name:tag
+
+# ┌───────────────────────────────────────────────────────────────────────────┐
+# │ Supported Workflows                                                       │
+# └───────────────────────────────────────────────────────────────────────────┘
+#
+# - docker-build-dockerfile.yaml
+# - docker-build-retag.yaml
+# - kubernetes-app-docker-dockerfile.yaml
+# - kubernetes-app-docker-retag.yaml
+# - kubernetes-app-manifests-only.yaml
+# - spec-check-filter-release.yaml

--- a/examples/docker-registry-logins-explicit.yaml
+++ b/examples/docker-registry-logins-explicit.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.40
     permissions:
       contents: write
       packages: write

--- a/examples/docker-registry-logins-ghcr-pat.yaml
+++ b/examples/docker-registry-logins-ghcr-pat.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.40
     permissions:
       contents: write
       packages: write

--- a/examples/docker-registry-logins-inherit.yaml
+++ b/examples/docker-registry-logins-inherit.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.40
     permissions:
       contents: write
       packages: write

--- a/examples/github-release-options.yaml
+++ b/examples/github-release-options.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.40
     permissions:
       contents: write
       packages: write
@@ -72,7 +72,7 @@ jobs:
 #
 # jobs:
 #   build:
-#     uses: kube-kaptain/buildon-github-actions/.github/workflows/kubernetes-app-docker-dockerfile.yaml@1.0.39
+#     uses: kube-kaptain/buildon-github-actions/.github/workflows/kubernetes-app-docker-dockerfile.yaml@1.0.40
 #     permissions:
 #       contents: write
 #       packages: write

--- a/examples/optional-test-scripts.yaml
+++ b/examples/optional-test-scripts.yaml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   build:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/kubernetes-app-docker-dockerfile.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/kubernetes-app-docker-dockerfile.yaml@1.0.40
     permissions:
       contents: write
       packages: write
@@ -129,6 +129,19 @@ jobs:
 # └─────────────────────────────────────────────────────────────────────────┘
 #     with:
 #       output-sub-path: 'build'  # Default is 'target'
+
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │ Multi-Registry Push                                                     │
+# └─────────────────────────────────────────────────────────────────────────┘
+# Push the same image to additional registries (e.g., multiple AWS accounts)
+# See docker-push-targets.yaml example for full details
+#
+#     with:
+#       docker-push-targets: |
+#         [
+#           {"registry": "123456789012.dkr.ecr.us-east-1.amazonaws.com"},
+#           {"registry": "other.registry.com", "base-path": "my-team"}
+#         ]
 
 # ┌─────────────────────────────────────────────────────────────────────────┐
 # │ Registry Credentials                                                    │

--- a/examples/quality-only.yaml
+++ b/examples/quality-only.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   quality:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/basic-quality-checks.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/basic-quality-checks.yaml@1.0.40
     permissions:
       contents: read
       checks: write

--- a/examples/spec-check-filter-release.yaml
+++ b/examples/spec-check-filter-release.yaml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   build:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/spec-check-filter-release.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/spec-check-filter-release.yaml@1.0.40
     permissions:
       contents: write
       packages: write
@@ -131,6 +131,19 @@ jobs:
 # └─────────────────────────────────────────────────────────────────────────┘
 #     with:
 #       output-sub-path: 'build'  # Default is 'target'
+
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │ Multi-Registry Push                                                     │
+# └─────────────────────────────────────────────────────────────────────────┘
+# Push the same image to additional registries (e.g., multiple AWS accounts)
+# See docker-push-targets.yaml example for full details
+#
+#     with:
+#       docker-push-targets: |
+#         [
+#           {"registry": "123456789012.dkr.ecr.us-east-1.amazonaws.com"},
+#           {"registry": "other.registry.com", "base-path": "my-team"}
+#         ]
 
 # ┌─────────────────────────────────────────────────────────────────────────┐
 # │ Registry Credentials                                                    │

--- a/examples/version-from-custom-pattern.yaml
+++ b/examples/version-from-custom-pattern.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/basic-quality-and-versioning.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/basic-quality-and-versioning.yaml@1.0.40
     permissions:
       contents: write
       checks: write

--- a/examples/version-from-dockerfile.yaml
+++ b/examples/version-from-dockerfile.yaml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   build:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.40
     permissions:
       contents: write
       packages: write

--- a/examples/version-from-retag-source-tag.yaml
+++ b/examples/version-from-retag-source-tag.yaml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   retag:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-retag.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-retag.yaml@1.0.40
     permissions:
       contents: write
       packages: write

--- a/examples/version-prefix-parts.yaml
+++ b/examples/version-prefix-parts.yaml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   build:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/docker-build-dockerfile.yaml@1.0.40
     permissions:
       contents: write
       packages: write

--- a/examples/versions-and-naming.yaml
+++ b/examples/versions-and-naming.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   version:
-    uses: kube-kaptain/buildon-github-actions/.github/workflows/versions-and-naming.yaml@1.0.39
+    uses: kube-kaptain/buildon-github-actions/.github/workflows/versions-and-naming.yaml@1.0.40
     permissions:
       contents: write
       checks: write

--- a/src/actions/docker-multi-push/action.yaml
+++ b/src/actions/docker-multi-push/action.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Kaptain contributors (Fred Cooke)
+
+name: 'Docker Multi-Push'
+description: 'Pushes Docker image to multiple registries'
+
+inputs:
+  docker-image-name:
+    description: 'Image name portion'
+    required: true
+  docker-tag:
+    description: 'Tag for images'
+    required: true
+  docker-push-targets:
+    description: 'JSON array of targets [{registry, base-path?}]'
+    required: true
+  is-release:
+    description: 'Whether to push (true) or skip (false)'
+    required: true
+
+outputs:
+  images-pushed:
+    description: 'Number of images pushed'
+    value: ${{ steps.push.outputs.IMAGES_PUSHED }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Push images
+      id: push
+      shell: bash
+      env:
+        DOCKER_IMAGE_NAME: ${{ inputs.docker-image-name }}
+        DOCKER_TAG: ${{ inputs.docker-tag }}
+        DOCKER_PUSH_TARGETS: ${{ inputs.docker-push-targets }}
+        IS_RELEASE: ${{ inputs.is-release }}
+      run: "${{ github.action_path }}/../../scripts/main/docker-multi-push"

--- a/src/actions/docker-multi-tag/action.yaml
+++ b/src/actions/docker-multi-tag/action.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Kaptain contributors (Fred Cooke)
+
+name: 'Docker Multi-Tag'
+description: 'Tags a Docker image for multiple registries'
+
+inputs:
+  docker-image-full-uri:
+    description: 'Full URI of the image to tag from'
+    required: true
+  docker-image-name:
+    description: 'Image name portion'
+    required: true
+  docker-tag:
+    description: 'Tag for images'
+    required: true
+  docker-push-targets:
+    description: 'JSON array of targets [{registry, base-path?}]'
+    required: true
+
+outputs:
+  images-tagged:
+    description: 'Number of images tagged'
+    value: ${{ steps.tag.outputs.IMAGES_TAGGED }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Tag images
+      id: tag
+      shell: bash
+      env:
+        DOCKER_IMAGE_FULL_URI: ${{ inputs.docker-image-full-uri }}
+        DOCKER_IMAGE_NAME: ${{ inputs.docker-image-name }}
+        DOCKER_TAG: ${{ inputs.docker-tag }}
+        DOCKER_PUSH_TARGETS: ${{ inputs.docker-push-targets }}
+      run: "${{ github.action_path }}/../../scripts/main/docker-multi-tag"

--- a/src/scripts/main/docker-multi-push
+++ b/src/scripts/main/docker-multi-push
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Kaptain contributors (Fred Cooke)
+#
+# docker-multi-push - Pushes Docker image to multiple registries
+#
+# Inputs (environment variables):
+#   DOCKER_IMAGE_NAME     - Image name portion (required)
+#   DOCKER_TAG            - Tag for images (required)
+#   DOCKER_PUSH_TARGETS   - JSON array of targets [{registry, base-path?}] (required)
+#   IS_RELEASE            - "true" to push, "false" to skip (default: false)
+#
+# Each target in the JSON array:
+#   registry  - Target registry (required)
+#   base-path - Optional base path within registry
+#
+# Outputs:
+#   IMAGES_PUSHED - Number of images pushed
+#
+set -euo pipefail
+
+# Required inputs
+DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:?DOCKER_IMAGE_NAME is required}"
+DOCKER_TAG="${DOCKER_TAG:?DOCKER_TAG is required}"
+DOCKER_PUSH_TARGETS="${DOCKER_PUSH_TARGETS:?DOCKER_PUSH_TARGETS is required}"
+
+# Optional inputs with defaults
+IS_RELEASE="${IS_RELEASE:-false}"
+
+# Output variable for GitHub Actions
+output_var() {
+  local name="${1}"
+  local value="${2}"
+
+  echo "${name}=${value}"
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "${name}=${value}" >> "${GITHUB_OUTPUT}"
+  fi
+}
+
+# Build full image URI from components
+build_image_uri() {
+  local registry="${1}"
+  local base_path="${2}"
+  local image_name="${3}"
+  local tag="${4}"
+
+  if [[ -n "${base_path}" ]]; then
+    echo "${registry}/${base_path}/${image_name}:${tag}"
+  else
+    echo "${registry}/${image_name}:${tag}"
+  fi
+}
+
+main() {
+  echo "=== Docker Multi-Push ===" >&2
+  echo "Image name: ${DOCKER_IMAGE_NAME}" >&2
+  echo "Tag: ${DOCKER_TAG}" >&2
+  echo "Is Release: ${IS_RELEASE}" >&2
+  echo "==========================" >&2
+
+  # Validate JSON before processing
+  if ! echo "${DOCKER_PUSH_TARGETS}" | jq -e 'type == "array"' > /dev/null 2>&1; then
+    echo "${LOG_ERROR_PREFIX:-}DOCKER_PUSH_TARGETS must be a valid JSON array${LOG_ERROR_SUFFIX:-}" >&2
+    exit 1
+  fi
+
+  if [[ "${IS_RELEASE}" != "true" ]]; then
+    echo "Skipping push (IS_RELEASE=${IS_RELEASE})" >&2
+    output_var "IMAGES_PUSHED" "0"
+    return 0
+  fi
+
+  local count=0
+
+  # Parse JSON and iterate over targets
+  while IFS= read -r target; do
+    local registry base_path target_uri
+
+    registry=$(echo "${target}" | jq -r '.registry')
+    base_path=$(echo "${target}" | jq -r '.["base-path"] // ""')
+
+    # Validate registry is present
+    if [[ -z "${registry}" ]] || [[ "${registry}" == "null" ]]; then
+      echo "${LOG_ERROR_PREFIX:-}Push target missing required 'registry' field${LOG_ERROR_SUFFIX:-}" >&2
+      exit 1
+    fi
+
+    target_uri=$(build_image_uri "${registry}" "${base_path}" "${DOCKER_IMAGE_NAME}" "${DOCKER_TAG}")
+
+    echo "Pushing: ${target_uri}" >&2
+    docker push "${target_uri}"
+
+    count=$((count + 1))
+  done < <(echo "${DOCKER_PUSH_TARGETS}" | jq -c '.[]')
+
+  output_var "IMAGES_PUSHED" "${count}"
+
+  echo "" >&2
+  echo "Docker Multi-Push complete: ${count} image(s) pushed" >&2
+}
+
+main "$@"

--- a/src/scripts/main/docker-multi-tag
+++ b/src/scripts/main/docker-multi-tag
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Kaptain contributors (Fred Cooke)
+#
+# docker-multi-tag - Tags a Docker image for multiple registries
+#
+# Inputs (environment variables):
+#   DOCKER_IMAGE_FULL_URI - Full URI of image to tag from (required)
+#   DOCKER_IMAGE_NAME     - Image name portion (required)
+#   DOCKER_TAG            - Tag for images (required)
+#   DOCKER_PUSH_TARGETS   - JSON array of targets [{registry, base-path?}] (required)
+#
+# Each target in the JSON array:
+#   registry  - Target registry (required)
+#   base-path - Optional base path within registry
+#
+# Outputs:
+#   IMAGES_TAGGED - Number of images tagged
+#
+set -euo pipefail
+
+# Required inputs
+DOCKER_IMAGE_FULL_URI="${DOCKER_IMAGE_FULL_URI:?DOCKER_IMAGE_FULL_URI is required}"
+DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:?DOCKER_IMAGE_NAME is required}"
+DOCKER_TAG="${DOCKER_TAG:?DOCKER_TAG is required}"
+DOCKER_PUSH_TARGETS="${DOCKER_PUSH_TARGETS:?DOCKER_PUSH_TARGETS is required}"
+
+# Output variable for GitHub Actions
+output_var() {
+  local name="${1}"
+  local value="${2}"
+
+  echo "${name}=${value}"
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "${name}=${value}" >> "${GITHUB_OUTPUT}"
+  fi
+}
+
+# Build full image URI from components
+build_image_uri() {
+  local registry="${1}"
+  local base_path="${2}"
+  local image_name="${3}"
+  local tag="${4}"
+
+  if [[ -n "${base_path}" ]]; then
+    echo "${registry}/${base_path}/${image_name}:${tag}"
+  else
+    echo "${registry}/${image_name}:${tag}"
+  fi
+}
+
+main() {
+  echo "=== Docker Multi-Tag ===" >&2
+  echo "Source image: ${DOCKER_IMAGE_FULL_URI}" >&2
+  echo "Image name: ${DOCKER_IMAGE_NAME}" >&2
+  echo "Tag: ${DOCKER_TAG}" >&2
+  echo "========================" >&2
+
+  # Validate JSON before processing
+  if ! echo "${DOCKER_PUSH_TARGETS}" | jq -e 'type == "array"' > /dev/null 2>&1; then
+    echo "${LOG_ERROR_PREFIX:-}DOCKER_PUSH_TARGETS must be a valid JSON array${LOG_ERROR_SUFFIX:-}" >&2
+    exit 1
+  fi
+
+  local count=0
+
+  # Parse JSON and iterate over targets
+  while IFS= read -r target; do
+    local registry base_path target_uri
+
+    registry=$(echo "${target}" | jq -r '.registry')
+    base_path=$(echo "${target}" | jq -r '.["base-path"] // ""')
+
+    # Validate registry is present
+    if [[ -z "${registry}" ]] || [[ "${registry}" == "null" ]]; then
+      echo "${LOG_ERROR_PREFIX:-}Push target missing required 'registry' field${LOG_ERROR_SUFFIX:-}" >&2
+      exit 1
+    fi
+
+    target_uri=$(build_image_uri "${registry}" "${base_path}" "${DOCKER_IMAGE_NAME}" "${DOCKER_TAG}")
+
+    echo "Tagging: ${DOCKER_IMAGE_FULL_URI} -> ${target_uri}" >&2
+    docker tag "${DOCKER_IMAGE_FULL_URI}" "${target_uri}"
+
+    count=$((count + 1))
+  done < <(echo "${DOCKER_PUSH_TARGETS}" | jq -c '.[]')
+
+  output_var "IMAGES_TAGGED" "${count}"
+
+  echo "" >&2
+  echo "Docker Multi-Tag complete: ${count} image(s) tagged" >&2
+}
+
+main "$@"

--- a/src/steps-common/docker-multi-push.yaml
+++ b/src/steps-common/docker-multi-push.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Kaptain contributors (Fred Cooke)
+
+- name: Push images to additional registries
+  id: docker-multi-push
+  if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'
+  uses: ./.github/buildon-github-actions/src/actions/docker-multi-push
+  with:
+    docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+    docker-tag: ${{ steps.versions.outputs.docker-tag }}
+    docker-push-targets: ${{ inputs.docker-push-targets }}
+    is-release: ${{ steps.versions.outputs.is-release }}

--- a/src/steps-common/docker-multi-tag.yaml
+++ b/src/steps-common/docker-multi-tag.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Kaptain contributors (Fred Cooke)
+
+- name: Tag images for additional registries
+  id: docker-multi-tag
+  if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'
+  uses: ./.github/buildon-github-actions/src/actions/docker-multi-tag
+  with:
+    docker-image-full-uri: ${{ steps.docker-build.outputs.docker-target-image-full-uri }}
+    docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+    docker-tag: ${{ steps.versions.outputs.docker-tag }}
+    docker-push-targets: ${{ inputs.docker-push-targets }}

--- a/src/steps-common/manifest-multi-push.yaml
+++ b/src/steps-common/manifest-multi-push.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Kaptain contributors (Fred Cooke)
+
+- name: Push manifest images to additional registries
+  id: manifest-multi-push
+  if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'
+  uses: ./.github/buildon-github-actions/src/actions/docker-multi-push
+  with:
+    docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+    docker-tag: ${{ steps.versions.outputs.docker-tag }}-manifests
+    docker-push-targets: ${{ inputs.docker-push-targets }}
+    is-release: ${{ steps.versions.outputs.is-release }}

--- a/src/steps-common/manifest-multi-tag.yaml
+++ b/src/steps-common/manifest-multi-tag.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Kaptain contributors (Fred Cooke)
+
+- name: Tag manifest images for additional registries
+  id: manifest-multi-tag
+  if: inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'
+  uses: ./.github/buildon-github-actions/src/actions/docker-multi-tag
+  with:
+    docker-image-full-uri: ${{ steps.manifest-repo-provider-package.outputs.manifests-uri }}
+    docker-image-name: ${{ steps.versions.outputs.docker-image-name }}
+    docker-tag: ${{ steps.versions.outputs.docker-tag }}-manifests
+    docker-push-targets: ${{ inputs.docker-push-targets }}

--- a/src/test/docker-multi-push.bats
+++ b/src/test/docker-multi-push.bats
@@ -1,0 +1,233 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Kaptain contributors (Fred Cooke)
+
+load helpers
+
+setup() {
+  setup_mock_docker
+  export GITHUB_OUTPUT=$(mktemp)
+}
+
+teardown() {
+  cleanup_mock_docker
+  rm -f "$GITHUB_OUTPUT"
+}
+
+# Required env vars for most tests
+set_required_env() {
+  export DOCKER_IMAGE_NAME="my-repo"
+  export DOCKER_TAG="1.0.0"
+  export IS_RELEASE="true"
+}
+
+# === Basic functionality ===
+
+@test "pushes image to single registry" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -eq 0 ]
+  assert_docker_called "push docker.io/my-repo:1.0.0"
+  assert_var_equals "IMAGES_PUSHED" "1"
+}
+
+@test "pushes image to multiple registries" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[
+    {"registry": "docker.io"},
+    {"registry": "quay.io"},
+    {"registry": "gcr.io"}
+  ]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -eq 0 ]
+  assert_docker_called "push docker.io/my-repo:1.0.0"
+  assert_docker_called "push quay.io/my-repo:1.0.0"
+  assert_docker_called "push gcr.io/my-repo:1.0.0"
+  assert_var_equals "IMAGES_PUSHED" "3"
+}
+
+@test "includes base-path when specified" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io", "base-path": "library"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -eq 0 ]
+  assert_docker_called "push docker.io/library/my-repo:1.0.0"
+  assert_var_equals "IMAGES_PUSHED" "1"
+}
+
+@test "handles mix of targets with and without base-path" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[
+    {"registry": "docker.io"},
+    {"registry": "quay.io", "base-path": "myorg"}
+  ]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -eq 0 ]
+  assert_docker_called "push docker.io/my-repo:1.0.0"
+  assert_docker_called "push quay.io/myorg/my-repo:1.0.0"
+  assert_var_equals "IMAGES_PUSHED" "2"
+}
+
+@test "handles nested base-path" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "myregistry.example.com", "base-path": "team/project"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -eq 0 ]
+  assert_docker_called "push myregistry.example.com/team/project/my-repo:1.0.0"
+  assert_var_equals "IMAGES_PUSHED" "1"
+}
+
+@test "handles ECR registry format" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "123456789012.dkr.ecr.us-east-1.amazonaws.com"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -eq 0 ]
+  assert_docker_called "push 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:1.0.0"
+  assert_var_equals "IMAGES_PUSHED" "1"
+}
+
+# === IS_RELEASE behavior ===
+
+@test "skips push when IS_RELEASE=false" {
+  set_required_env
+  export IS_RELEASE="false"
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -eq 0 ]
+  assert_docker_not_called "push"
+  assert_var_equals "IMAGES_PUSHED" "0"
+}
+
+@test "defaults IS_RELEASE to false" {
+  export DOCKER_IMAGE_NAME="my-repo"
+  export DOCKER_TAG="1.0.0"
+  unset IS_RELEASE
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -eq 0 ]
+  assert_docker_not_called "push"
+  assert_var_equals "IMAGES_PUSHED" "0"
+}
+
+@test "pushes when IS_RELEASE=true" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -eq 0 ]
+  assert_docker_called "push docker.io/my-repo:1.0.0"
+  assert_var_equals "IMAGES_PUSHED" "1"
+}
+
+# === Error handling ===
+
+@test "fails when DOCKER_IMAGE_NAME missing" {
+  export DOCKER_TAG="1.0.0"
+  export IS_RELEASE="true"
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -ne 0 ]
+  assert_output_contains "DOCKER_IMAGE_NAME"
+}
+
+@test "fails when DOCKER_TAG missing" {
+  export DOCKER_IMAGE_NAME="my-repo"
+  export IS_RELEASE="true"
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -ne 0 ]
+  assert_output_contains "DOCKER_TAG"
+}
+
+@test "fails when DOCKER_PUSH_TARGETS missing" {
+  export DOCKER_IMAGE_NAME="my-repo"
+  export DOCKER_TAG="1.0.0"
+  export IS_RELEASE="true"
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -ne 0 ]
+  assert_output_contains "DOCKER_PUSH_TARGETS"
+}
+
+@test "fails when target missing registry field" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"base-path": "myorg"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -ne 0 ]
+  assert_output_contains "missing required 'registry' field"
+}
+
+@test "fails when target has null registry" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": null}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -ne 0 ]
+  assert_output_contains "missing required 'registry' field"
+}
+
+@test "fails on invalid JSON" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -ne 0 ]
+  assert_output_contains "must be a valid JSON array"
+}
+
+# === Output formatting ===
+
+@test "outputs count to GITHUB_OUTPUT" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}, {"registry": "quay.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -eq 0 ]
+
+  # Check GITHUB_OUTPUT file was written
+  grep -q "IMAGES_PUSHED=2" "$GITHUB_OUTPUT"
+}
+
+@test "outputs zero count when skipped" {
+  set_required_env
+  export IS_RELEASE="false"
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -eq 0 ]
+
+  grep -q "IMAGES_PUSHED=0" "$GITHUB_OUTPUT"
+}
+
+@test "outputs progress messages to stderr" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -eq 0 ]
+  assert_output_contains "Docker Multi-Push"
+  assert_output_contains "Is Release: true"
+  assert_output_contains "Pushing:"
+}
+
+@test "outputs skip message when not releasing" {
+  set_required_env
+  export IS_RELEASE="false"
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-push"
+  [ "$status" -eq 0 ]
+  assert_output_contains "Skipping push"
+}

--- a/src/test/docker-multi-tag.bats
+++ b/src/test/docker-multi-tag.bats
@@ -1,0 +1,187 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Kaptain contributors (Fred Cooke)
+
+load helpers
+
+setup() {
+  setup_mock_docker
+  export GITHUB_OUTPUT=$(mktemp)
+}
+
+teardown() {
+  cleanup_mock_docker
+  rm -f "$GITHUB_OUTPUT"
+}
+
+# Required env vars for most tests
+set_required_env() {
+  export DOCKER_IMAGE_FULL_URI="ghcr.io/test/my-repo:1.0.0"
+  export DOCKER_IMAGE_NAME="my-repo"
+  export DOCKER_TAG="1.0.0"
+}
+
+# === Basic functionality ===
+
+@test "tags image to single registry" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -eq 0 ]
+  assert_docker_called "tag ghcr.io/test/my-repo:1.0.0 docker.io/my-repo:1.0.0"
+  assert_var_equals "IMAGES_TAGGED" "1"
+}
+
+@test "tags image to multiple registries" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[
+    {"registry": "docker.io"},
+    {"registry": "quay.io"},
+    {"registry": "gcr.io"}
+  ]'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -eq 0 ]
+  assert_docker_called "tag ghcr.io/test/my-repo:1.0.0 docker.io/my-repo:1.0.0"
+  assert_docker_called "tag ghcr.io/test/my-repo:1.0.0 quay.io/my-repo:1.0.0"
+  assert_docker_called "tag ghcr.io/test/my-repo:1.0.0 gcr.io/my-repo:1.0.0"
+  assert_var_equals "IMAGES_TAGGED" "3"
+}
+
+@test "includes base-path when specified" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io", "base-path": "library"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -eq 0 ]
+  assert_docker_called "tag ghcr.io/test/my-repo:1.0.0 docker.io/library/my-repo:1.0.0"
+  assert_var_equals "IMAGES_TAGGED" "1"
+}
+
+@test "handles mix of targets with and without base-path" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[
+    {"registry": "docker.io"},
+    {"registry": "quay.io", "base-path": "myorg"}
+  ]'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -eq 0 ]
+  assert_docker_called "tag ghcr.io/test/my-repo:1.0.0 docker.io/my-repo:1.0.0"
+  assert_docker_called "tag ghcr.io/test/my-repo:1.0.0 quay.io/myorg/my-repo:1.0.0"
+  assert_var_equals "IMAGES_TAGGED" "2"
+}
+
+@test "handles nested base-path" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "myregistry.example.com", "base-path": "team/project"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -eq 0 ]
+  assert_docker_called "tag ghcr.io/test/my-repo:1.0.0 myregistry.example.com/team/project/my-repo:1.0.0"
+  assert_var_equals "IMAGES_TAGGED" "1"
+}
+
+@test "handles ECR registry format" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "123456789012.dkr.ecr.us-east-1.amazonaws.com"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -eq 0 ]
+  assert_docker_called "tag ghcr.io/test/my-repo:1.0.0 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:1.0.0"
+  assert_var_equals "IMAGES_TAGGED" "1"
+}
+
+# === Error handling ===
+
+@test "fails when DOCKER_IMAGE_FULL_URI missing" {
+  export DOCKER_IMAGE_NAME="my-repo"
+  export DOCKER_TAG="1.0.0"
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -ne 0 ]
+  assert_output_contains "DOCKER_IMAGE_FULL_URI"
+}
+
+@test "fails when DOCKER_IMAGE_NAME missing" {
+  export DOCKER_IMAGE_FULL_URI="ghcr.io/test/my-repo:1.0.0"
+  export DOCKER_TAG="1.0.0"
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -ne 0 ]
+  assert_output_contains "DOCKER_IMAGE_NAME"
+}
+
+@test "fails when DOCKER_TAG missing" {
+  export DOCKER_IMAGE_FULL_URI="ghcr.io/test/my-repo:1.0.0"
+  export DOCKER_IMAGE_NAME="my-repo"
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -ne 0 ]
+  assert_output_contains "DOCKER_TAG"
+}
+
+@test "fails when DOCKER_PUSH_TARGETS missing" {
+  export DOCKER_IMAGE_FULL_URI="ghcr.io/test/my-repo:1.0.0"
+  export DOCKER_IMAGE_NAME="my-repo"
+  export DOCKER_TAG="1.0.0"
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -ne 0 ]
+  assert_output_contains "DOCKER_PUSH_TARGETS"
+}
+
+@test "fails when target missing registry field" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"base-path": "myorg"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -ne 0 ]
+  assert_output_contains "missing required 'registry' field"
+}
+
+@test "fails when target has null registry" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": null}]'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -ne 0 ]
+  assert_output_contains "missing required 'registry' field"
+}
+
+@test "fails on invalid JSON" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -ne 0 ]
+  assert_output_contains "must be a valid JSON array"
+}
+
+# === Output formatting ===
+
+@test "outputs count to GITHUB_OUTPUT" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}, {"registry": "quay.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -eq 0 ]
+
+  # Check GITHUB_OUTPUT file was written
+  grep -q "IMAGES_TAGGED=2" "$GITHUB_OUTPUT"
+}
+
+@test "outputs progress messages to stderr" {
+  set_required_env
+  export DOCKER_PUSH_TARGETS='[{"registry": "docker.io"}]'
+
+  run "$SCRIPTS_DIR/docker-multi-tag"
+  [ "$status" -eq 0 ]
+  assert_output_contains "Docker Multi-Tag"
+  assert_output_contains "Source image: ghcr.io/test/my-repo:1.0.0"
+  assert_output_contains "Tagging:"
+}

--- a/src/workflow-templates/docker-build-dockerfile.yaml
+++ b/src/workflow-templates/docker-build-dockerfile.yaml
@@ -68,6 +68,11 @@ on:
         required: false
         type: string
         default: ''
+      docker-push-targets:
+        description: 'JSON array of additional push targets [{registry, base-path?}]'
+        required: false
+        type: string
+        default: ''
       # Version generator inputs (pass-through)
       release-branch:
         description: 'The release branch name'
@@ -302,6 +307,11 @@ jobs:
       # INJECT: docker-build-dockerfile
       # INJECT: github-check-end(name="Docker Build", id="check-docker-build")
 
+      # === Docker Multi-Tag ===
+      # INJECT: github-check-start(name="Docker Multi-Tag", id="check-docker-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+      # INJECT: docker-multi-tag
+      # INJECT: github-check-end(name="Docker Multi-Tag", id="check-docker-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+
       # === Post-docker Tests ===
       # INJECT: github-check-start(name="Post-docker Tests", id="check-post-docker", if="inputs.post-docker-tests-script-sub-path != ''")
       # INJECT: post-docker-tests
@@ -321,6 +331,11 @@ jobs:
       # INJECT: github-check-start(name="Docker Push", id="check-docker-push", if="steps.versions.outputs.is-release == 'true'")
       # INJECT: docker-push
       # INJECT: github-check-end(name="Docker Push", id="check-docker-push", if="steps.versions.outputs.is-release == 'true'")
+
+      # === Docker Multi-Push ===
+      # INJECT: github-check-start(name="Docker Multi-Push", id="check-docker-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+      # INJECT: docker-multi-push
+      # INJECT: github-check-end(name="Docker Multi-Push", id="check-docker-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
 
       # === GitHub Release ===
       # INJECT: github-check-start(name="GitHub Release", id="check-github-release", if="inputs.github-release-enabled == true && steps.versions.outputs.is-release == 'true'")

--- a/src/workflow-templates/docker-build-retag.yaml
+++ b/src/workflow-templates/docker-build-retag.yaml
@@ -34,6 +34,11 @@ on:
         required: false
         type: string
         default: ''
+      docker-push-targets:
+        description: 'JSON array of additional push targets [{registry, base-path?}]'
+        required: false
+        type: string
+        default: ''
       # Version generator inputs (pass-through)
       release-branch:
         description: 'The release branch name'
@@ -298,6 +303,11 @@ jobs:
       # INJECT: docker-build-retag
       # INJECT: github-check-end(name="Docker Retag", id="check-docker-retag")
 
+      # === Docker Multi-Tag ===
+      # INJECT: github-check-start(name="Docker Multi-Tag", id="check-docker-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+      # INJECT: docker-multi-tag
+      # INJECT: github-check-end(name="Docker Multi-Tag", id="check-docker-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+
       # === GitHub Release Prepare ===
       # INJECT: github-check-start(name="GitHub Release Prepare", id="check-github-release-prepare", if="inputs.github-release-enabled == true")
       # INJECT: github-release-prepare-docker
@@ -312,6 +322,11 @@ jobs:
       # INJECT: github-check-start(name="Docker Push", id="check-docker-push", if="steps.versions.outputs.is-release == 'true'")
       # INJECT: docker-push
       # INJECT: github-check-end(name="Docker Push", id="check-docker-push", if="steps.versions.outputs.is-release == 'true'")
+
+      # === Docker Multi-Push ===
+      # INJECT: github-check-start(name="Docker Multi-Push", id="check-docker-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+      # INJECT: docker-multi-push
+      # INJECT: github-check-end(name="Docker Multi-Push", id="check-docker-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
 
       # === GitHub Release ===
       # INJECT: github-check-start(name="GitHub Release", id="check-github-release", if="inputs.github-release-enabled == true && steps.versions.outputs.is-release == 'true'")

--- a/src/workflow-templates/kubernetes-app-docker-dockerfile.yaml
+++ b/src/workflow-templates/kubernetes-app-docker-dockerfile.yaml
@@ -84,6 +84,11 @@ on:
         required: false
         type: string
         default: ''
+      docker-push-targets:
+        description: 'JSON array of additional push targets [{registry, base-path?}]'
+        required: false
+        type: string
+        default: ''
       # Version generator inputs (pass-through)
       release-branch:
         description: 'The release branch name'
@@ -348,6 +353,11 @@ jobs:
       # INJECT: docker-build-dockerfile
       # INJECT: github-check-end(name="Docker Build", id="check-docker-build")
 
+      # === Docker Multi-Tag ===
+      # INJECT: github-check-start(name="Docker Multi-Tag", id="check-docker-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+      # INJECT: docker-multi-tag
+      # INJECT: github-check-end(name="Docker Multi-Tag", id="check-docker-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+
       # === Post-docker Tests ===
       # INJECT: github-check-start(name="Post-docker Tests", id="check-post-docker", if="inputs.post-docker-tests-script-sub-path != ''")
       # INJECT: post-docker-tests
@@ -367,6 +377,11 @@ jobs:
       # INJECT: github-check-start(name="Package Manifests for Repo Provider", id="check-manifest-repo-provider-package")
       # INJECT: manifest-repo-provider-package
       # INJECT: github-check-end(name="Package Manifests for Repo Provider", id="check-manifest-repo-provider-package")
+
+      # === Manifest Multi-Tag ===
+      # INJECT: github-check-start(name="Manifest Multi-Tag", id="check-manifest-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'")
+      # INJECT: manifest-multi-tag
+      # INJECT: github-check-end(name="Manifest Multi-Tag", id="check-manifest-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'")
 
       # === Post-package Tests ===
       # INJECT: github-check-start(name="Post-package Tests", id="check-post-package", if="inputs.post-package-tests-script-sub-path != ''")
@@ -388,10 +403,20 @@ jobs:
       # INJECT: docker-push
       # INJECT: github-check-end(name="Docker Push", id="check-docker-push", if="steps.versions.outputs.is-release == 'true'")
 
+      # === Docker Multi-Push ===
+      # INJECT: github-check-start(name="Docker Multi-Push", id="check-docker-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+      # INJECT: docker-multi-push
+      # INJECT: github-check-end(name="Docker Multi-Push", id="check-docker-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+
       # === Manifest Repo Provider Publish ===
       # INJECT: github-check-start(name="Publish Manifests via Repo Provider", id="check-manifest-repo-provider-publish", if="steps.versions.outputs.is-release == 'true'")
       # INJECT: manifest-repo-provider-publish
       # INJECT: github-check-end(name="Publish Manifests via Repo Provider", id="check-manifest-repo-provider-publish", if="steps.versions.outputs.is-release == 'true'")
+
+      # === Manifest Multi-Push ===
+      # INJECT: github-check-start(name="Manifest Multi-Push", id="check-manifest-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'")
+      # INJECT: manifest-multi-push
+      # INJECT: github-check-end(name="Manifest Multi-Push", id="check-manifest-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'")
 
       # === GitHub Release ===
       # INJECT: github-check-start(name="GitHub Release", id="check-github-release", if="inputs.github-release-enabled == true && steps.versions.outputs.is-release == 'true'")

--- a/src/workflow-templates/kubernetes-app-docker-retag.yaml
+++ b/src/workflow-templates/kubernetes-app-docker-retag.yaml
@@ -86,6 +86,11 @@ on:
         required: false
         type: string
         default: ''
+      docker-push-targets:
+        description: 'JSON array of additional push targets [{registry, base-path?}]'
+        required: false
+        type: string
+        default: ''
       # Version generator inputs (pass-through)
       release-branch:
         description: 'The release branch name'
@@ -344,6 +349,11 @@ jobs:
       # INJECT: docker-build-retag
       # INJECT: github-check-end(name="Docker Retag", id="check-docker-retag")
 
+      # === Docker Multi-Tag ===
+      # INJECT: github-check-start(name="Docker Multi-Tag", id="check-docker-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+      # INJECT: docker-multi-tag
+      # INJECT: github-check-end(name="Docker Multi-Tag", id="check-docker-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+
       # === Pre-package Prepare ===
       # INJECT: github-check-start(name="Pre-package Prepare", id="check-pre-package-prepare", if="inputs.pre-package-prepare-script-sub-path != ''")
       # INJECT: pre-package-prepare
@@ -358,6 +368,11 @@ jobs:
       # INJECT: github-check-start(name="Package Manifests for Repo Provider", id="check-manifest-repo-provider-package")
       # INJECT: manifest-repo-provider-package
       # INJECT: github-check-end(name="Package Manifests for Repo Provider", id="check-manifest-repo-provider-package")
+
+      # === Manifest Multi-Tag ===
+      # INJECT: github-check-start(name="Manifest Multi-Tag", id="check-manifest-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'")
+      # INJECT: manifest-multi-tag
+      # INJECT: github-check-end(name="Manifest Multi-Tag", id="check-manifest-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'")
 
       # === Post-package Tests ===
       # INJECT: github-check-start(name="Post-package Tests", id="check-post-package", if="inputs.post-package-tests-script-sub-path != ''")
@@ -379,10 +394,20 @@ jobs:
       # INJECT: docker-push
       # INJECT: github-check-end(name="Docker Push", id="check-docker-push", if="steps.versions.outputs.is-release == 'true'")
 
+      # === Docker Multi-Push ===
+      # INJECT: github-check-start(name="Docker Multi-Push", id="check-docker-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+      # INJECT: docker-multi-push
+      # INJECT: github-check-end(name="Docker Multi-Push", id="check-docker-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+
       # === Manifest Repo Provider Publish ===
       # INJECT: github-check-start(name="Publish Manifests via Repo Provider", id="check-manifest-repo-provider-publish", if="steps.versions.outputs.is-release == 'true'")
       # INJECT: manifest-repo-provider-publish
       # INJECT: github-check-end(name="Publish Manifests via Repo Provider", id="check-manifest-repo-provider-publish", if="steps.versions.outputs.is-release == 'true'")
+
+      # === Manifest Multi-Push ===
+      # INJECT: github-check-start(name="Manifest Multi-Push", id="check-manifest-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'")
+      # INJECT: manifest-multi-push
+      # INJECT: github-check-end(name="Manifest Multi-Push", id="check-manifest-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'")
 
       # === GitHub Release ===
       # INJECT: github-check-start(name="GitHub Release", id="check-github-release", if="inputs.github-release-enabled == true && steps.versions.outputs.is-release == 'true'")

--- a/src/workflow-templates/kubernetes-app-manifests-only.yaml
+++ b/src/workflow-templates/kubernetes-app-manifests-only.yaml
@@ -68,6 +68,11 @@ on:
         required: false
         type: string
         default: ''
+      docker-push-targets:
+        description: 'JSON array of additional push targets [{registry, base-path?}]'
+        required: false
+        type: string
+        default: ''
       # Version generator inputs (pass-through)
       release-branch:
         description: 'The release branch name'
@@ -319,6 +324,11 @@ jobs:
       # INJECT: manifest-repo-provider-package
       # INJECT: github-check-end(name="Package Manifests for Repo Provider", id="check-manifest-repo-provider-package")
 
+      # === Manifest Multi-Tag ===
+      # INJECT: github-check-start(name="Manifest Multi-Tag", id="check-manifest-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'")
+      # INJECT: manifest-multi-tag
+      # INJECT: github-check-end(name="Manifest Multi-Tag", id="check-manifest-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'")
+
       # === Post-package Tests ===
       # INJECT: github-check-start(name="Post-package Tests", id="check-post-package", if="inputs.post-package-tests-script-sub-path != ''")
       # INJECT: post-package-tests
@@ -338,6 +348,11 @@ jobs:
       # INJECT: github-check-start(name="Publish Manifests via Repo Provider", id="check-manifest-repo-provider-publish", if="steps.versions.outputs.is-release == 'true'")
       # INJECT: manifest-repo-provider-publish
       # INJECT: github-check-end(name="Publish Manifests via Repo Provider", id="check-manifest-repo-provider-publish", if="steps.versions.outputs.is-release == 'true'")
+
+      # === Manifest Multi-Push ===
+      # INJECT: github-check-start(name="Manifest Multi-Push", id="check-manifest-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'")
+      # INJECT: manifest-multi-push
+      # INJECT: github-check-end(name="Manifest Multi-Push", id="check-manifest-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true' && inputs.manifests-repo-provider-type == 'docker'")
 
       # === GitHub Release ===
       # INJECT: github-check-start(name="GitHub Release", id="check-github-release", if="inputs.github-release-enabled == true && steps.versions.outputs.is-release == 'true'")

--- a/src/workflow-templates/spec-check-filter-release.yaml
+++ b/src/workflow-templates/spec-check-filter-release.yaml
@@ -67,6 +67,11 @@ on:
         required: false
         type: string
         default: ''
+      docker-push-targets:
+        description: 'JSON array of additional push targets [{registry, base-path?}]'
+        required: false
+        type: string
+        default: ''
       # Version generator inputs (pass-through)
       release-branch:
         description: 'The release branch name'
@@ -331,6 +336,11 @@ jobs:
           config-value-trailing-newline: ${{ inputs.config-value-trailing-newline }}
       # INJECT: github-check-end(name="Docker Build", id="check-docker-build")
 
+      # === Docker Multi-Tag ===
+      # INJECT: github-check-start(name="Docker Multi-Tag", id="check-docker-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+      # INJECT: docker-multi-tag
+      # INJECT: github-check-end(name="Docker Multi-Tag", id="check-docker-multi-tag", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+
       # === Spec Validate ===
       # INJECT: github-check-start(name="Spec Validate", id="check-spec-validate")
       - name: Spec validate
@@ -404,6 +414,11 @@ jobs:
       # INJECT: github-check-start(name="Docker Push", id="check-docker-push", if="steps.versions.outputs.is-release == 'true'")
       # INJECT: docker-push
       # INJECT: github-check-end(name="Docker Push", id="check-docker-push", if="steps.versions.outputs.is-release == 'true'")
+
+      # === Docker Multi-Push ===
+      # INJECT: github-check-start(name="Docker Multi-Push", id="check-docker-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
+      # INJECT: docker-multi-push
+      # INJECT: github-check-end(name="Docker Multi-Push", id="check-docker-multi-push", if="inputs.docker-push-targets != '' && steps.versions.outputs.is-release == 'true'")
 
       # === GitHub Release ===
       # INJECT: github-check-start(name="GitHub Release", id="check-github-release", if="inputs.github-release-enabled == true && steps.versions.outputs.is-release == 'true'")


### PR DESCRIPTION
…even the places it's unlikely to be useful. Great for dual publishing as a backup and great for multi AWS account publishing for multi environment lambda use without cross account perms or perms to a centralised nexus or anything like that. Enjoy.